### PR TITLE
ZTS: Add Fedora 41, remove Fedora 39

### DIFF
--- a/.github/workflows/scripts/qemu-2-start.sh
+++ b/.github/workflows/scripts/qemu-2-start.sh
@@ -52,15 +52,15 @@ case "$OS" in
     OSNAME="Debian 12"
     URL="https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-generic-amd64.qcow2"
     ;;
-  fedora39)
-    OSNAME="Fedora 39"
-    OSv="fedora39"
-    URL="https://download.fedoraproject.org/pub/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-39-1.5.x86_64.qcow2"
-    ;;
   fedora40)
     OSNAME="Fedora 40"
-    OSv="fedora39"
+    OSv="fedora-unknown"
     URL="https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2"
+    ;;
+  fedora41)
+    OSNAME="Fedora 41"
+    OSv="fedora-unknown"
+    URL="https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2"
     ;;
   freebsd13-3r)
     OSNAME="FreeBSD 13.3-RELEASE"

--- a/.github/workflows/scripts/qemu-3-deps.sh
+++ b/.github/workflows/scripts/qemu-3-deps.sh
@@ -66,7 +66,13 @@ function rhel() {
   echo "##[endgroup]"
 
   echo "##[group]Install Development Tools"
-  sudo dnf group install -y "Development Tools"
+
+  # Alma wants "Development Tools", Fedora 41 wants "development-tools"
+  if ! sudo dnf group install -y "Development Tools" ; then
+    echo "Trying 'development-tools' instead of 'Development Tools'"
+    sudo dnf group install -y development-tools
+  fi
+
   sudo dnf install -y \
     acl attr bc bzip2 cryptsetup curl dbench dkms elfutils-libelf-devel fio \
     gdb git jq kernel-rpm-macros ksh libacl-devel libaio-devel \

--- a/.github/workflows/scripts/qemu-4-build.sh
+++ b/.github/workflows/scripts/qemu-4-build.sh
@@ -83,7 +83,7 @@ function rpm_build_and_install() {
   echo "##[endgroup]"
 
   echo "##[group]Install"
-  run sudo dnf -y --skip-broken localinstall $(ls *.rpm | grep -v src.rpm)
+  run sudo dnf -y --nobest install $(ls *.rpm | grep -v src.rpm)
   echo "##[endgroup]"
 
 }

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Generate OS config and CI type
         id: os
         run: |
-          FULL_OS='["almalinux8", "almalinux9", "centos-stream9", "debian11", "debian12", "fedora39", "fedora40", "freebsd13-4r", "freebsd14-0r", "freebsd14-1s", "ubuntu20", "ubuntu22", "ubuntu24"]'
-          QUICK_OS='["almalinux8", "almalinux9", "debian12", "fedora40", "freebsd13-3r", "freebsd14-1r", "ubuntu24"]'
+          FULL_OS='["almalinux8", "almalinux9", "centos-stream9", "debian11", "debian12", "fedora40", "fedora41", "freebsd13-4r", "freebsd14-0r", "freebsd14-1s", "ubuntu20", "ubuntu22", "ubuntu24"]'
+          QUICK_OS='["almalinux8", "almalinux9", "debian12", "fedora41", "freebsd13-3r", "freebsd14-1r", "ubuntu24"]'
           # determine CI type when running on PR
           ci_type="full"
           if ${{ github.event_name == 'pull_request' }}; then
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # rhl:     almalinux8, almalinux9, centos-stream9, fedora39, fedora40
+        # rhl:     almalinux8, almalinux9, centos-stream9, fedora40, fedora41
         # debian:  debian11, debian12, ubuntu20, ubuntu22, ubuntu24
         # misc:    archlinux, tumbleweed
         # FreeBSD Release: freebsd13-3r, freebsd13-4r, freebsd14-0r, freebsd14-1r

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_dryrun_output.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_dryrun_output.ksh
@@ -148,9 +148,9 @@ done
 
 # Foreach test create pool, add -n devices and check output.
 for (( i=0; i < ${#tests[@]}; i+=1 )); do
-	typeset tree="${tests[$i].tree}"
-	typeset add="${tests[$i].add}"
-	typeset want="${tests[$i].want}"
+	tree="${tests[$i].tree}"
+	add="${tests[$i].add}"
+	want="${tests[$i].want}"
 
 	log_must eval zpool create "$TESTPOOL" $tree
 	log_must poolexists "$TESTPOOL"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_dryrun_output.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_dryrun_output.ksh
@@ -124,8 +124,8 @@ done
 
 # Foreach test create pool, add -n devices and check output.
 for (( i=0; i < ${#tests[@]}; i+=1 )); do
-	typeset tree="${tests[$i].tree}"
-	typeset want="${tests[$i].want}"
+	tree="${tests[$i].tree}"
+	want="${tests[$i].want}"
 
 	typeset out="$(log_must eval "zpool create -n '$TESTPOOL' $tree" | \
 	    sed /^SUCCESS/d)"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_dryrun_output.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_dryrun_output.ksh
@@ -133,9 +133,9 @@ done
 
 # Foreach test create pool, add -n devices and check output.
 for (( i=0; i < ${#tests[@]}; i+=1 )); do
-	typeset tree="${tests[$i].tree}"
-	typeset devs="${tests[$i].devs}"
-	typeset want="${tests[$i].want}"
+	tree="${tests[$i].tree}"
+	devs="${tests[$i].devs}"
+	want="${tests[$i].want}"
 
 	log_must eval zpool create "$TESTPOOL" $tree
 	log_must poolexists "$TESTPOOL"


### PR DESCRIPTION
### Motivation and Context
Support Fedora 41, remove Fedora 39

### Description
Fedora 41 was released 10/19/24, and Fedora 39 is EOL on 11/12/24. Update Fedora runners in the test suite.

### How Has This Been Tested?
runners will test

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
